### PR TITLE
round up temperature

### DIFF
--- a/ansiweather
+++ b/ansiweather
@@ -74,7 +74,7 @@ weather=$($fetch_cmd http://api.openweathermap.org/data/2.5/weather?q=$location\
 ###[ Process Weather data ]####################################################
 
 city=$(echo $weather | jq -r '.name')
-temperature=$(echo $weather | jq '.main.temp')
+temperature=$(printf '%.0f' $(echo $weather | jq '.main.temp'))
 humidity=$(echo $weather | jq '.main.humidity')
 pressure=$(echo $weather | jq '.main.pressure')
 sky=$(echo $weather | jq -r '.weather[0].main')


### PR DESCRIPTION
The API sometimes returns unreadable floats as temperature.

This PR rounds up to integers (0 decimals).
I bet nobody can feel the difference even from 0 to 1 Celcius, so floats are just noise IMO.

e.g. http://api.openweathermap.org/data/2.5/weather?q=Stockholm,SE&units=metric

``` json
{"coord":{"lon":18.064899,"lat":59.332581},"sys":{"country":"SE","sunrise":1382334105,"sunset":1382368967},"weather":[{"id":801,"main":"Clouds","description":"few clouds","icon":"02n"}],"base":"global stations","main":{"temp":0.080000000000041,"pressure":1021,"humidity":92,"temp_min":-1,"temp_max":1},"wind":{"speed":0.5,"deg":0},"clouds":{"all":24},"dt":1382392200,"id":2673730,"name":"Stockholm","cod":200}
```
