### PR TITLE
When given, take location from the first command-line arg

### DIFF
--- a/ansiweather
+++ b/ansiweather
@@ -36,6 +36,9 @@ function get_config {
 
 # Location : example "Moscow,RU"
 location=$(get_config "location" || echo "Moscow,RU")
+if [ ! -z "$1" ]; then
+    location=$1;
+fi
 
 # System of Units : "metric" or "imperial"
 units=$(get_config "units" || echo "metric")


### PR DESCRIPTION
So that:

```
./ansiweather
```

Will use the ~/.ansiweatherrc location, but:

```
./ansiweather Rome
```

will instead tell you the weather in Rome.
