### PR TITLE
Add antigen compatable plugin description

### DIFF
--- a/ansiweather.plugin.zsh
+++ b/ansiweather.plugin.zsh
@@ -1,0 +1,1 @@
+export PATH=${PATH}:$(dirname $0)


### PR DESCRIPTION
This adds antigen support for ZSH. See https://github.com/zsh-users/antigen for more details.

This allows a user to start using this library using the command:

antigen bundle matthewfranglen/ansiweather

Which handles downloading the repository and adding the command to your path. This commit provides support for ZSH. Antigen can support other shells, and I can write those descriptors if you like this sort of thing.
