### PR TITLE
Change detection of BSD vs GNU date

### DIFF
--- a/ansiweather
+++ b/ansiweather
@@ -144,10 +144,12 @@ weather=$($fetch_cmd "http://api.openweathermap.org/data/2.5/$api_cmd?q=$locatio
 
 function epoch_to_date {
 	unamestr=$(uname)
-	if [[ "$unamestr" == 'Linux' ]]; then
-		ret=$(date -d @$1 +"%a %b %d")
-	else 
+	if date -j -r $1 +"%a %b %d" > /dev/null 2>&1; then
+		# BSD
 		ret=$(date -j -r $1 +"%a %b %d")
+	else
+		# GNU
+		ret=$(date -d @$1 +"%a %b %d")
 	fi
 	echo $ret
 }


### PR DESCRIPTION
[Previous detection](https://github.com/fcambus/ansiweather/issues/32) was checking for uname Linux/Debian,
but Debian can run in a GNU environment as well.

Ref: http://stackoverflow.com/questions/8747845/how-can-i-detect-bsd-vs-gnu-version-of-date-in-shell-script
