### PR TITLE
Handle sunrise and sunset being unset

### DIFF
--- a/ansiweather
+++ b/ansiweather
@@ -208,7 +208,10 @@ if [ $forecast != 0 ]
 then
 	period="none"
 else
-	if [ $now -ge $sunset ] || [ $now -le $sunrise ]
+	if [ -z "$sunset" ] || [ -z "$sunrise" ]
+	then
+		period="day"
+	elif [ $now -ge $sunset ] || [ $now -le $sunrise ]
 	then
 		period="night"
 	else


### PR DESCRIPTION
For "Walluf, Germany", the sunrise and sunset variables
were being left unset resulting in:

```
./ansiweather: line 211: [: 1385212168: unary operator expected
./ansiweather: line 211: [: 1385212168: unary operator expected
```
