### PR TITLE
fix incorrectly escaping ampersand

### DIFF
--- a/ansiweather
+++ b/ansiweather
@@ -138,7 +138,7 @@ thunderstorm=$(get_config "thunderstorm" || echo "\xe2\x9a\xa1")
 
 fetch_cmd=$(get_config "fetch_cmd" || echo "curl -s")
 api_cmd=$([[ $forecast != 0 ]] && echo "forecast/daily" || echo "weather")
-weather=$($fetch_cmd "http://api.openweathermap.org/data/2.5/$api_cmd?q=$location\&units=$units")
+weather=$($fetch_cmd "http://api.openweathermap.org/data/2.5/$api_cmd?q=$location&units=$units")
 
 if [ -z "$weather" ]
 then


### PR DESCRIPTION
The bug is introduced in commit 175e04a862429903c17e5653e9fe1eda694354db, which quoted the URI. There is no need for escaping ampersand in quoted string, which only produces unwanted slash.

With some configuration:

```
location:North Pole
fetch_cmd:curl -vv
```

The output of curl shows the problem

```
> GET /data/2.5/weather?q=North%20Pole\&units=metric HTTP/1.1
```

For some unknown reason, city with one word results no error, only city names with space(s) have this issue.
