### PR TITLE
added sunrise and sunset data to the display

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ After cloning the repository, simply invoke the script by typing :
 
 Any configuration options may also be passed in as command line options.
 
-	./ansiweather -l Moscow,RU -u metric -s true -f 5
+	./ansiweather -l Moscow,RU -u metric -s true -f 5 -d true
 
 
 
@@ -46,6 +46,7 @@ Example : `~/.ansiweatherrc`
 	location:Moscow,RU
 	fetch_cmd:ftp -V -o -
 	units:metric
+	daylight:true
 
 ### Location
 
@@ -93,6 +94,11 @@ Show upcoming forecast for the next `N` days (for 0 <= N <= 7). `0` will show st
 
 	forecast:5
 
+### Display sunrise / sunset
+
+Toggle daylight display. Value can be either `true` or `false`.
+
+	daylight:false
 
 
 ## License

--- a/ansiweather
+++ b/ansiweather
@@ -89,8 +89,11 @@ symbols=$(get_config "symbols" || echo true)
 # Show forecast : How many days, example "5". "0" is standard output
 forecast=$(get_config "forecast" || echo 0)
 
+# Show daylight : "true" or "false"
+daylight=$(get_config "daylight" || echo false)
+
 # Or get config options from command line flags
-while getopts l:u:s:f: option
+while getopts l:u:s:f:d: option
 do
 	case "${option}"
 	in
@@ -98,6 +101,7 @@ do
 		u) units=${OPTARG};;
 		s) symbols=${OPTARG};;
 		f) forecast=${OPTARG};;
+                d) daylight=${OPTARG};;
 	esac
 done
 
@@ -345,5 +349,14 @@ then
 	output="$output\033[0m"
 	echo -e "$output"
 else
-	echo -e "$background$text $greeting_text $city $delimiter$data $temperature $scale $icon$dashes$text $wind_text $delimiter$data $wind $speed_unit $direction $dashes$text $humidity_text $delimiter$data $humidity % $dashes$text $pressure_text $delimiter$data $pressure $pressure_unit $dashes$text $sunrise_text $delimiter$data $sunrise_time $dashes$text $sunset_text $delimiter$data $sunset_time\033[0m"
+        output="$background$text $greeting_text $city $delimiter$data $temperature $scale $icon$dashes$text $wind_text $delimiter$data $wind $speed_unit $direction $dashes$text $humidity_text $delimiter$data $humidity % $dashes$text $pressure_text $delimiter$data $pressure $pressure_unit"
+
+        if [ $daylight = true ]
+        then
+            output="$output $dashes$text $sunrise_text $delimiter$data $sunrise_time $dashes$text $sunset_text $delimiter$data $sunset_time"
+        fi
+
+        output="$output \033[0m"
+
+        echo -e "$output"
 fi

--- a/ansiweatherrc.example
+++ b/ansiweatherrc.example
@@ -5,6 +5,7 @@ fetch_cmd:curl -s
 units:metric
 symbols:true
 forecast:0
+daylight:true
 
 # Text and Colors
 background:\033[44m


### PR DESCRIPTION
I saw that the sunrise and sunset data was returned by the call to openweathermap, so I added it in the output. I find it useful, maybe someone else will too.

It does make the output line a bit longer, so if that's a problem, I can put some logic in there to look at the $COLUMNS variable and only show the sunrise and sunset if there's enough room without wrapping the line.
