### PR TITLE
small documentation changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,17 +75,23 @@ Example : `ftp -V -o -`
 
 	fetch_cmd:ftp -V -o -
 
+Default: `curl -s`
+
 ### System of Units
 
 Both `metric` and `imperial` systems are supported.
 
 	units:metric
 
+Default: `metric`
+
 ### Display symbols
 
 Toggle Unicode symbols display. Value can be either `true` or `false` (requires an Unicode capable display).
 
 	symbols:true
+
+Default: `true`
 
 ### Display forecast
 

--- a/ansiweather
+++ b/ansiweather
@@ -77,7 +77,7 @@ function auto_locate {
 # Location : example "Moscow,RU"
 location=$(get_config "location" || auto_locate || echo "Moscow,RU")
 
-#check and replace spaces for curl requests
+# check and replace spaces for curl requests
 location=$( printf "%s\n" "$location" | sed 's/ /%20/g' )
 
 # System of Units : "metric" or "imperial"


### PR DESCRIPTION
Now the defaults for fetch_cmd, units and symbols are called out explicitly.
