### PR TITLE
Documentation update for bc dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ AnsiWeather requires the following dependencies :
 
 - A command to fetch HTTP data such as [cURL](http://curl.haxx.se) or [wget](https://www.gnu.org/software/wget/)
 - jq (lightweight and flexible command-line JSON processor) : http://stedolan.github.io/jq/
+- [bc](https://www.gnu.org/software/bc/) (arbitrary precision numeric processing language)
 
 
 


### PR DESCRIPTION
I noticed `bc` is not installed in CentOS 6.x minimal.
I think it's good README says about this dependency.

Let me know your idea.
