### PR TITLE
use a same prefix in ansiweatherrc

### DIFF
--- a/ansiweather
+++ b/ansiweather
@@ -25,7 +25,7 @@ function get_config {
 	ret=""
 	if [ -f $config_file ]
 	then
-		ret=$(grep "^$1" $config_file | awk -F: '{print $2}') 
+		ret=$(grep "^$1:" $config_file | awk -F: '{print $2}') 
 	fi
 
 	if [ "X$ret" = "X" ]


### PR DESCRIPTION
get_config function doesn't work if some keys have a same prefix(e.g. wind).

```
wind:false
wind_text:Wind
```
