### PR TITLE
Make -f take an optional argument, otherwise it defaults to 5

### DIFF
--- a/ansiweather
+++ b/ansiweather
@@ -90,14 +90,15 @@ forecast=$(get_config "forecast" || echo 0)
 daylight=$(get_config "daylight" || echo false)
 
 # Or get config options from command line flags
-while getopts :l:u:s:f:d: option
+while getopts :l:u:s:f:Fd: option
 do
 	case "${option}"
 	in
 		l) location=${OPTARG};;
 		u) units=${OPTARG};;
 		s) symbols=${OPTARG};;
-		f) forecast=${OPTARG-5};;
+		f) forecast=${OPTARG};;
+		F) forecast="5";;
 		d) daylight=${OPTARG};;
 	esac
 done


### PR DESCRIPTION
Ideally the `-f` or another argument should activate "spit out forecast as well", but since that would require more changes to the script, I made it so that `ansiweather -f` is enough to spit out the forecast.

I assumed 5 is the default for the openweathermap.org . If it's not, then I'll change the default.
