### PR TITLE
Correct dashes for forecast

### DIFF
--- a/ansiweather
+++ b/ansiweather
@@ -338,11 +338,7 @@ then
 		then
 			icon="$(get_icon ${sky[$i]})"
 		fi
-		output="$output $text${dates[$i]}: $data${highs[$i]}$text/$data${lows[$i]} $scale $icon"
-		if [ $i -lt $(($forecast-1)) ]
-		then
-			output="$output $dashes"
-		fi
+		output="$output $dashes $text${dates[$i]}: $data${highs[$i]}$text/$data${lows[$i]} $scale $icon"
 	done
 else
 	if [ $symbols = true ]


### PR DESCRIPTION
discovered with this config

```
location:Stockholm,SE
units:metric
symbols:true
fetch_cmd:/usr/bin/curl -s
daylight:true
background:\033[0m
text:\033[30;1m
data:\033[32;1m
delimiter:\t
dashes:\n
greeting_text:\n
wind_text:Wind  
forecast:5
```

PS: minor improvements in the first 2 commits
