### PR TITLE
fix getopts optstring

### DIFF
--- a/ansiweather
+++ b/ansiweather
@@ -90,7 +90,7 @@ forecast=$(get_config "forecast" || echo 0)
 daylight=$(get_config "daylight" || echo false)
 
 # Or get config options from command line flags
-while getopts :l:u:s:f:Fd: option
+while getopts l:u:s:f:Fd: option
 do
 	case "${option}"
 	in


### PR DESCRIPTION
It looks like we don't need the first `:`.

`:l:u:s:f:Fd:`
`l:u:s:f:Fd:`
