### PR TITLE
Suggestion: Move config file to ~/.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Weather data comes from the `OpenWeatherMap` free weather API.
 
 ## Requirements
 
-AnsiWeather requires the following dependencies : 
+AnsiWeather requires the following dependencies :
 
 - A command to fetch HTTP data such as [cURL](http://curl.haxx.se) or [wget](https://www.gnu.org/software/wget/)
 - [jq](http://stedolan.github.io/jq/) (lightweight and flexible command-line JSON processor)
@@ -37,10 +37,10 @@ Any configuration options may also be passed in as command line options :
 
 ## Configuration
 
-The following configuration options (detailed below) are available and should
-be set according to your location and preferences.
-
-Config options can also be set in ~/.ansiweatherrc :
+The default config file is ~/.ansiweatherrc. The environment varibale
+ANSIWEATHERRC can be set to overwrite this. The following configuration options
+(detailed below) are available and should be set according to your location and
+preferences.
 
 Example : `~/.ansiweatherrc`
 

--- a/ansiweather
+++ b/ansiweather
@@ -19,13 +19,13 @@
 
 LC_NUMERIC=C
 
-config_file=~/.ansiweatherrc
+config_file=${ANSIWEATHERRC:-~/.ansiweatherrc}
 
 function get_config {
 	ret=""
 	if [ -f $config_file ]
 	then
-		ret=$(grep "^$1:" $config_file | awk -F: '{print $2}') 
+		ret=$(grep "^$1:" $config_file | awk -F: '{print $2}')
 	fi
 
 	if [ "X$ret" = "X" ]
@@ -44,10 +44,10 @@ fetch_cmd=$(get_config "fetch_cmd" || echo "curl -s")
 
 jqpath="`which jq`"
 if [ "$jqpath" == "" ]
-then 
+then
 	echo -e "\njq binary is not found, please download it from http://stedolan.github.io/jq/ and put it in your PATH"
 	exit 255
-fi 
+fi
 
 
 
@@ -341,7 +341,7 @@ function get_icon {
 if [ $forecast != 0 ]
 then
 	output="$background$text $city forecast $text$delimiter "
-	
+
 	i=0
 	while [ $i -lt $forecast ]
 	do


### PR DESCRIPTION
Is propose to move the config file to ~/.config/ansiweather/*whatever*. This corresponds to the [XDG specification](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) (in order to fully comply with the standard some environment variables also need to be honored but that is not of central interest *for me*).

Two ideas come to mind in order not to break compatibility for old users:

1. allow for both config files (~/.answeather and ~/.config/ansiweather/*whatever*) and try them in some given order
2. introduce a environment variable ANSIWEATHERRC to specify the filename instead of moving the default location

The reason I suggest this is to remove as many config files from $HOME as possible.