### PR TITLE
Removing duplicate variable

### DIFF
--- a/ansiweather
+++ b/ansiweather
@@ -47,7 +47,6 @@ location=
 units=
 symbols=
 forecast=
-forecast=
 daylight=
 
 # Get config options from command line flags


### PR DESCRIPTION
I noticed "forecast" is defined twice.