### PR TITLE
Prefer xargs printf over hardcoding printf path

### DIFF
--- a/ansiweather
+++ b/ansiweather
@@ -250,7 +250,7 @@ then
 	forecast=$([ "$forecast" -gt "$flength" ] && echo "$flength" || echo "$forecast")
 else
 	city=$(echo "$weather" | jq -r '.name')
-	temperature=$(/usr/bin/printf "%.0f" "$(echo "$weather" | jq '.main.temp')")
+	temperature=$(echo "$weather" | jq '.main.temp' | xargs printf "%.0f")
 	humidity=$(echo "$weather" | jq '.main.humidity')
 	pressure=$(echo "$weather" | jq '.main.pressure')
 	sky=$(echo "$weather" | jq -r '.weather[0].main')
@@ -330,7 +330,7 @@ case $units in
 		scale="°C"
 		speed_unit="m/s"
 		pressure_unit="hPa"
-		pressure=$(/usr/bin/printf "%.0f" "$pressure")
+		pressure=$(echo "$pressure" | xargs printf "%.0f")
 		;;
 	imperial)
 		scale="°F"
@@ -338,7 +338,7 @@ case $units in
 		pressure_unit="inHg"
 		if [ "$forecast" = 0 ]
 		then
-			pressure=$(/usr/bin/printf "%.2f" "$(echo "$pressure*0.0295" | bc)")
+			pressure=$(echo "$pressure*0.0295" | bc | xargs printf "%.2f")
 		fi
 		;;
 esac
@@ -394,8 +394,8 @@ then
 	do
 		day=$(echo "$weather" | jq ".list[$i]")
 		date=$(epoch_to_date "$(echo "$day" | jq -r '.dt')")
-		low=$(/usr/bin/printf "%.0f" "$(echo "$day" | jq -r '.temp.min')")
-		high=$(/usr/bin/printf "%.0f" "$(echo "$day" | jq -r '.temp.max')")
+		low=$(echo "$day" | jq -r '.temp.min' | xargs printf "%.0f")
+		high=$(echo "$day" | jq -r '.temp.max' | xargs printf "%.0f")
 
 		icon=""
 		if [ "$symbols" = true ]


### PR DESCRIPTION
This trick is to enforce system-wide version instead of the
builtin one.
