### PR TITLE
Force bc to return ints, no decimals for 'shift'

### DIFF
--- a/ansiweather
+++ b/ansiweather
@@ -261,7 +261,7 @@ set -- N NNE NE ENE E ESE SE SSE S SSW SW WSW W WNW NW NNW
 
 if [ "$forecast" = 0 ]
 then
-	shift "$(echo "($azimuth + 11.25)/22.5 % 16" | bc)"
+	shift "$(echo "scale=0; ($azimuth + 11.25)/22.5 % 16" | bc)"
 	direction=$1
 fi
 


### PR DESCRIPTION
The result from bc's calculation will return verious
decimal places due to bc's default scale (20).

sh's 'shift' doesn't like decimals.

Force scale=0 to cause bc to return integers.