### PR TITLE
Send jq stderr to /dev/null

### DIFF
--- a/ansiweather
+++ b/ansiweather
@@ -213,7 +213,7 @@ then
 	exit
 fi
 
-status_code=$(echo "$weather" | jq -r '.cod')
+status_code=$(echo "$weather" | jq -r '.cod' 2>/dev/null)
 
 if [ "$status_code" != 200 ]
 then


### PR DESCRIPTION
Since the exit status of `$fetch_cmd` is not checked (which seems to make sense given the open- endedness of `$fetch_cmd`), failed lookups output can get passed to `jq`. This results in a `parse error: Invalid numeric literal at line 1, column 8` error. 