### PR TITLE
Multiline output in forecast and issue #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,15 @@ country code. A list of country codes is available [here](http://www.statdns.com
 
 In case no location is specified, AnsiWeather will fallback to the default location.
 
+For cities with spaces in their names, the spaces must be escaped using a backslash or by enclosing in quotes.
+
 Example : `Rzeszow,PL`
 
 	location:Rzeszow,PL
+
+	`"Los Angeles"` or `los\ angeles`
+
+	location: Los Angeles,US
 
 ### Fetch Command
 

--- a/ansiweather
+++ b/ansiweather
@@ -377,7 +377,7 @@ then
 			icon=$(get_icon "$sky")
 		fi
 
-		output="$output$text$date: $data$high$text/$data$low $scale $icon"
+		output="$output$text\n$date: $data$high$text/$data$low $scale $icon"
 		if [ $i -lt $((forecast-1)) ]
 		then
 			output="$output$dashes "


### PR DESCRIPTION
Bash is parsing the spaces. Made a note of it in the read me.

A new line before the date, in forecast. Easily readable in a column format.

EDIT: Issue #92 . Not number one.