### PR TITLE
Feature: Allow toggle of wind, humidity, and pressure display

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,16 @@ Show upcoming forecast for the next `N` days (for 0 <= N <= 7). `0` will show st
 
 Default: `0`
 
+### Display wind / humidity / pressure
+
+Toggle wind, humidity, and/or pressure display. Values can be either `true` or `false`.
+
+	show_wind:true
+	show_humidity:true
+	show_pressure:true
+
+Default: `true`
+
 ### Display sunrise / sunset
 
 Toggle daylight display. Value can be either `true` or `false`.

--- a/ansiweather
+++ b/ansiweather
@@ -133,6 +133,15 @@ fi
 # Display symbols : "true" or "false" (requires an Unicode capable display)
 [ -z "$symbols" ] && symbols=$(get_config "symbols" || echo true)
 
+# Show wind : "true" or "false"
+show_wind=$(get_config "show_wind" || echo true)
+
+# Show humidity : "true" or "false"
+show_humidity=$(get_config "show_humidity" || echo true)
+
+# Show pressure : "true" or "false"
+show_pressure=$(get_config "show_pressure" || echo true)
+
 dateformat=$(get_config "dateformat" || echo "%a %b %d")
 timeformat=$(get_config "timeformat" || echo "%b %d %r")
 
@@ -391,7 +400,22 @@ else
 	then
 		icon="$(get_icon "$sky")"
 	fi
-	output="$background$text $greeting_text $city $delimiter$data $temperature $scale $icon$dashes$text $wind_text $delimiter$data $wind $speed_unit $direction $dashes$text $humidity_text $delimiter$data $humidity %% $dashes$text $pressure_text $delimiter$data $pressure $pressure_unit "
+	output="$background$text $greeting_text $city $delimiter$data $temperature $scale $icon"
+
+	if [ "$show_wind" = true ]
+	then
+		output="$output$dashes$text $wind_text $delimiter$data $wind $speed_unit $direction "
+	fi
+
+	if [ "$show_humidity" = true ]
+	then
+		output="$output$dashes$text $humidity_text $delimiter$data $humidity %% "
+	fi
+
+	if [ "$show_pressure" = true ]
+	then
+		output="$output$dashes$text $pressure_text $delimiter$data $pressure $pressure_unit "
+	fi
 
 	if [ "$daylight" = true ]
 	then

--- a/ansiweatherrc.example
+++ b/ansiweatherrc.example
@@ -8,6 +8,9 @@ forecast:0
 daylight:false
 ansi:true
 symbols:true
+show_wind:true
+show_humidity:true
+show_pressure:true
 dateformat:%a %b %d
 timeformat:%b %d %r
 


### PR DESCRIPTION
I was removing the pressure information on my setup, but I figured rather than deleting that info each time I upgraded it would be easier to have this be a setting in the configuration. While I was at it I added the same toggle setting for wind and humidity.

I'm not sure if you'd prefer to name the settings something different (show_[x]) or perhaps change daylight to show_daylight for consistency?

_BTW this is my first pull request. So I'm sorry if I'm doing something wrong or odd. Show mercy. 😃_ 