### PR TITLE
Use emojis on Darwin in Apple Terminal

### DIFF
--- a/ansiweather
+++ b/ansiweather
@@ -149,17 +149,29 @@ forecast_text=$(get_config "forecast_text" || echo "forecast")
 
 ###[ Unicode Symbols for icons ]###############################################
 
-sun=$(get_config "sun" || echo "\033[33;1m\xe2\x98\x80")
-moon=$(get_config "moon" || echo "\033[36m\xe2\x98\xbd")
-clouds=$(get_config "clouds" || echo "\033[37;1m\xe2\x98\x81")
-rain=$(get_config "rain" || echo "\033[37;1m\xe2\x98\x94")
-fog=$(get_config "fog" || echo "\033[37;1m\xe2\x96\x92")
-mist=$(get_config "mist" || echo "\033[34m\xe2\x96\x91")
-haze=$(get_config "haze" || echo "\033[33m\xe2\x96\x91")
-snow=$(get_config "snow" || echo "\033[37;1m\xe2\x9d\x84")
-thunderstorm=$(get_config "thunderstorm" || echo "\033[33;1m\xe2\x9a\xa1")
-
-
+if [ `uname` == "Darwin" ] && [ "$TERM_PROGRAM" == "Apple_Terminal" ]
+then
+    # We can use emoji
+    sun=$(get_config "sun" || echo "\033[33;1m☀️")
+    moon=$(get_config "moon" || echo "\033[36m🌙")
+    clouds=$(get_config "clouds" || echo "\033[37;1m☁️")
+    rain=$(get_config "rain" || echo "\033[37;1m🌧")
+    fog=$(get_config "fog" || echo "\033[37;1m🌫")
+    mist=$(get_config "mist" || echo "\033[34m🌫")
+    haze=$(get_config "haze" || echo "\033[33m🌫")
+    snow=$(get_config "snow" || echo "\033[37;1m❄️")
+    thunderstorm=$(get_config "thunderstorm" || echo "\033[33;1m⛈")
+else
+    sun=$(get_config "sun" || echo "\033[33;1m\xe2\x98\x80")
+    moon=$(get_config "moon" || echo "\033[36m\xe2\x98\xbd")
+    clouds=$(get_config "clouds" || echo "\033[37;1m\xe2\x98\x81")
+    rain=$(get_config "rain" || echo "\033[37;1m\xe2\x98\x94")
+    fog=$(get_config "fog" || echo "\033[37;1m\xe2\x96\x92")
+    mist=$(get_config "mist" || echo "\033[34m\xe2\x96\x91")
+    haze=$(get_config "haze" || echo "\033[33m\xe2\x96\x91")
+    snow=$(get_config "snow" || echo "\033[37;1m\xe2\x9d\x84")
+    thunderstorm=$(get_config "thunderstorm" || echo "\033[33;1m\xe2\x9a\xa1")
+fi
 
 ###[ Fetch Weather data ]######################################################
 


### PR DESCRIPTION
Apple Terminal is capable of rendering emojis. This replaces
the normal characters with the applicable emoji versions when the
conditions in the title are met. Pass in `-s true` to enable the
weather symbols, like it works right now.