### PR TITLE
Respect freedesktop/XDG spec for configuration

### DIFF
--- a/ansiweather
+++ b/ansiweather
@@ -20,7 +20,15 @@
 
 LC_ALL=C; export LC_ALL
 
-config_file=${ANSIWEATHERRC:-~/.ansiweatherrc}
+if [ -n "$ANSIWEATHERRC" ] ; then
+	config_file="$ANSIWEATHERRC"
+elif [ -s "$XDG_CONFIG_HOME"/ansiweather/config ] ; then
+	config_file="$XDG_CONFIG_HOME"/ansiweather/config
+elif [ -s "$HOME"/ansiweather/config ] ; then
+	config_file="$HOME"/ansiweather/config
+else
+	config_file=~/.ansiweatherrc
+fi
 
 get_config() {
 	ret=""

--- a/ansiweather
+++ b/ansiweather
@@ -24,8 +24,8 @@ if [ -n "$ANSIWEATHERRC" ] ; then
 	config_file="$ANSIWEATHERRC"
 elif [ -s "$XDG_CONFIG_HOME"/ansiweather/config ] ; then
 	config_file="$XDG_CONFIG_HOME"/ansiweather/config
-elif [ -s "$HOME"/ansiweather/config ] ; then
-	config_file="$HOME"/ansiweather/config
+elif [ -s "$HOME"/.config/ansiweather/config ] ; then
+	config_file="$HOME"/.config/ansiweather/config
 else
 	config_file=~/.ansiweatherrc
 fi


### PR DESCRIPTION
Reference: https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
```
$XDG_CONFIG_HOME defines the base directory relative to which user specific                                                                                                                                          
configuration files should be stored. If $XDG_CONFIG_HOME is either not set or                                                                                                                                       
empty, a default equal to $HOME/.config should be used.
```

I retained fall-back behavior for `~/.ansiweatherrc` for backward compatibility.