### PR TITLE
Remove leading whitespace in $output

### DIFF
--- a/ansiweather
+++ b/ansiweather
@@ -399,7 +399,7 @@ else
 	then
 		icon="$(get_icon "$sky")"
 	fi
-	output="$background$text $greeting_text $city$delimiter$data $temperature $scale $icon"
+	output="$background$text$greeting_text $city$delimiter$data $temperature $scale $icon"
 
 	if [ "$show_uvi" = true ]
 	then


### PR DESCRIPTION
Closes #117

You can modify the `background`, `text`, `greeting`, or `forecast` configs to get this space back, but this makes it so that by default the output is aligned with the side of the terminal and/or the beginning of the terminal prompt.