### PR TITLE
Use cut instead of awk for reading the config file

### DIFF
--- a/ansiweather
+++ b/ansiweather
@@ -34,7 +34,7 @@ get_config() {
 	ret=""
 	if [ -f "$config_file" ]
 	then
-		ret=$(grep "^$1:" "$config_file" | awk -F: '{print $2}')
+		ret=$(grep "^$1:" "$config_file" | cut -d: -f2-)
 	fi
 
 	if [ "X$ret" = "X" ]


### PR DESCRIPTION
The way the config file is currently read prevents using the colon (`:`) as part of the config value. Setting e.g. `timeformat:%H:%M` will result in only the hour being displayed.

Using `cut` instead of `awk` would allow reading the config file as currently, while ignoring any but the first occurrence of the key-value separator.