### PR TITLE
removed "-" sign when temp is 0, fixes issue #152

### DIFF
--- a/ansiweather
+++ b/ansiweather
@@ -235,7 +235,7 @@ then
 	forecast=$([ "$forecast" -gt "$flength" ] && echo "$flength" || echo "$forecast")
 else
 	city=$(echo "$weather" | jq -r '.name')
-	temperature=$(echo "$weather" | jq '.main.temp' | xargs printf "%.0f")
+	temperature=$(echo "$weather" | jq '.main.temp' | xargs printf "%.0f" | sed 's/^-0/0/')
 	humidity=$(echo "$weather" | jq '.main.humidity')
 	feels_like=$(echo "$weather" | jq '.main.feels_like' | xargs printf "%.0f")
 	pressure=$(echo "$weather" | jq '.main.pressure')

--- a/ansiweather
+++ b/ansiweather
@@ -237,7 +237,7 @@ else
 	city=$(echo "$weather" | jq -r '.name')
 	temperature=$(echo "$weather" | jq '.main.temp' | xargs printf "%.0f" | sed 's/^-0/0/')
 	humidity=$(echo "$weather" | jq '.main.humidity')
-	feels_like=$(echo "$weather" | jq '.main.feels_like' | xargs printf "%.0f")
+	feels_like=$(echo "$weather" | jq '.main.feels_like' | xargs printf "%.0f" | sed 's/^-0/0/')
 	pressure=$(echo "$weather" | jq '.main.pressure')
 	sky=$(echo "$weather" | jq -r '.weather[0].main')
 	sunrise=$(echo "$weather" | jq '.sys.sunrise')


### PR DESCRIPTION
Tested with:
```json
{"coord":{"lon":15.4306,"lat":40.9021},"weather":[{"id":801,"main":"Clouds","description":"few clouds","icon":"02n"}],"base":"stations","main":{"temp":-0.08,"feels_like":-2.89,"temp_min":-0.98,"temp_max":0.08,"pressure":1018,"humidity":76,"sea_level":1018,"grnd_level":945},"visibility":10000,"wind":{"speed":2.46,"deg":200,"gust":2.42},"clouds":{"all":19},"dt":1701061471,"sys":{"type":2,"id":2035784,"country":"IT","sunrise":1701064735,"sunset":1701099179},"timezone":3600,"id":3181187,"name":"Calitri","cod":200}
```
Before:
![image](https://github.com/fcambus/ansiweather/assets/63904486/75a10d8a-cbfa-4551-9f66-7fb61e835f6a)

Fix:
Piped output to `sed` to replace `-0` with `0`

After:
![image](https://github.com/fcambus/ansiweather/assets/63904486/9eaff37d-5f8c-4487-a2ea-6b4bc5cc9729)
