### PR TITLE
Update README to document 'Feels like' and clarify 'UV Index' heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,15 @@ show standard output.
 
 Default: `0`
 
-### Display wind / humidity / pressure
+### Display Feels like
+
+Toggle "Feels like" display. Value can be either `true` or `false`.
+
+	show_feels_like:false
+
+Default: `false`
+
+### Display UV Index / wind / humidity / pressure
 
 Toggle UV Index, wind, humidity, and/or pressure display. Values can be either
 `true` or `false`.


### PR DESCRIPTION
Hi,

I noticed a couple of minor omissions in the README and have updated it to be more complete.

This commit adds documentation for the 'show_feels_like' configuration option to the README.md, which was previously missing.

It also updates the heading of the subsequent section to explicitly mention 'UV Index', ensuring clarity and consistency in the configuration options documentation.

Thanks for your time and for maintaining this great tool!